### PR TITLE
Added proper theme retrieve to fix inconsistent styles on 'Go back/edit' confirmation modal

### DIFF
--- a/src/components/modals/ReportActionModal.tsx
+++ b/src/components/modals/ReportActionModal.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "@/hooks/useTranslation";
-import theme from "@/styles/theme";
 import {
   alpha,
   Button,
@@ -8,6 +7,7 @@ import {
   DialogContent,
   DialogTitle,
   Typography,
+  useTheme,
 } from "@mui/material";
 
 interface ReportActionModalProps {
@@ -24,6 +24,7 @@ export const ReportActionModal = ({
   onFresh,
 }: ReportActionModalProps) => {
   const { t } = useTranslation();
+  const theme = useTheme();
   return (
     <Dialog
       open={open}


### PR DESCRIPTION
## Related Issues
- Closes #15 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Documentation update
- [ ] DevOps/CI-CD update

## Changelog
- Fixed the modal styling that wasn't applying the chosen theme correctly

<img width="1439" height="891" alt="image" src="https://github.com/user-attachments/assets/f88ce4fb-351c-451f-a7f6-538b8a67fa8a" />


## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [ ] Unit tests are updated/passing
- [x] I have updated the changelog with my changes
- [x] No breaking changes (or clearly documented if there are)
